### PR TITLE
Modify environment.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ It's a companion project to an R-shiny based image annotation app that is not ye
 Use anaconda or miniconda to create a python environment using the included `environment.yml`
 
 ```
-conda create -n cyto_39 python=3.9
-conda env update
+conda env create -f environment.yml
 ```
 
 Please note that this is specifically pinned to python 3.9 due to dependency versions; we make experimental use of the [CEFAS plankton model available through SciVision](https://sci.vision/#/model/resnet50-plankton), which in turn uses an older version of pytorch that isn't packaged above python 3.9.

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: test
+name: cyto_39
 channels:
   - pytorch
   - conda-forge

--- a/environment.yml
+++ b/environment.yml
@@ -1,21 +1,20 @@
-name: cyto_39
+name: test
 channels:
+  - pytorch
   - conda-forge
+  - defaults
 dependencies:
-  - numpy
+  - python=3.9
+  - pytorch=1.10.0
+  - mkl=2024.0
+  - chromadb=0.5.3
+  - intake-xarray
+  - scikit-image
   - pandas
-  - s3fs
-  - matplotlib
+  - pytest
   - python-dotenv
-  - dask
+  - s3fs
+  - pip
   - pip:
-    - pytest
-    - imagecodecs
-    - intake # for reading scivision
-    - torch==1.10.0 # install before cefas_scivision; it needs this version
     - scivision
-    - scikit-image
-    - setuptools==69.5.1 # because this bug https://github.com/pytorch/serve/issues/3176
-    - tiffile
-    - git+https://github.com/alan-turing-institute/plankton-cefas-scivision@main # torch version
-    - chromadb
+    - git+https://github.com/alan-turing-institute/plankton-cefas-scivision@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ name = "cyto_ml"
 version = "0.1"
 description = "This package supports the processing and analysis of plankton sample data"
 readme = "README.md"
-requires-python = "<3.10"
+requires-python = "==3.9.*"
 [tool.setuptools]
 py-modules = []


### PR DESCRIPTION
## Overview

This PR makes a small change to `environment.yml` so that 

1. Only direct dependencies are included
2. Everything that can be installed using `conda install` is installed using `conda install`, instead of `pip install`
3. chromadb is pinned to 0.5.3

I also modified the supported python versions in `pyproject.toml` to reflect the fact that we aren't supporting <=3.8 as far as I can tell.

Finally, I've slightly tweaked the installation instructions in `README.md`.

## Dependencies

Issues like the one we've just encountered with `chromadb` 0.5.4 are going to occur, and it's in these situations where I always seem to end up rediscovering how brittle conda environments with mixed conda and pip dependencies are - see e.g. [this article](https://www.anaconda.com/blog/using-pip-in-a-conda-environment). Concretely, it took me about 5 attempts to create an environment that passed the tests by manually installing the packages in the existing `environment.yml`.

Acknowledging that there is a reasonable case for using conda here since there are several non-Python dependencies that we might one day want to exert control over (but like... will we?), I've changed `environment.yml` so as to use `conda install` instead of `pip` wherever possible. 

I think the direct dependencies we need are

- pytorch 1.10.0
	- I have to downgrade MKL `mkl=2024.0` to fix [this bug](https://github.com/pytorch/pytorch/issues/123097)
- pandas
- python-dotenv
- s3fs
- pytest
- intake-xarray
	- This depends on scikit-image although it does not list it as a dependency...hmm
- chromadb (pinned to 0.5.3 for now)
- scivision
- resnet50_cefas (plankton-cefas-scivision)

The rest are I think indirect.

Of the direct dependencies, only scivision and resnet50_cefas cannot be installed using `conda install`.

So to me a sensible `environment.yml` looks something like this

```yaml
name: cyto_39
channels:
  - pytorch
  - conda-forge
  - defaults
dependencies:
  - python=3.9
  - pytorch=1.10.0
  - mkl=2024.0  # see https://github.com/pytorch/pytorch/issues/123097
  - chromadb=0.5.3
  - intake-xarray
  - scikit-image  # intake-xarray dependency
  - pandas
  - pytest
  - python-dotenv
  - s3fs
  - pip
  - pip:
    - scivision
    - git+https://github.com/alan-turing-institute/plankton-cefas-scivision@main
```

If I then run the following in the root of the repository,

```sh
$ conda env create -f environment.yml
$ conda activate cyto_39
$ python -m pip install .
$ python -m pytest
```

I get `1 failed, 4 passed, 9 warnings in 4.74s` where the failed test is just the device mismatch mentioned in [#5](https://github.com/NERC-CEH/plankton_ml/pull/5#discussion_r1685818442), and easily fixable.

## Notes

I also have `channel_priority` set to `strict` in my `.condarc`, which is [now recommended](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority).

Some of the failed attempts resulted in `IOError: [Errno 9] Bad file descriptor` for reasons I failed to understand.