### PR TITLE
Minimum change to reflect new bucket locations

### DIFF
--- a/cyto_ml/data/s3.py
+++ b/cyto_ml/data/s3.py
@@ -3,6 +3,7 @@
 import s3fs
 from dotenv import load_dotenv
 import os
+import pandas as pd
 
 load_dotenv()
 
@@ -18,3 +19,12 @@ def s3_endpoint():
         client_kwargs={"endpoint_url": os.environ["ENDPOINT"]},
     )
     return fs
+
+
+def image_index(endpoint: s3fs.S3FileSystem, location: str):
+    """Find and likely later filter records in a bucket"""
+    index = endpoint.ls(location)
+    return pd.DataFrame(
+        [f"{os.environ['ENDPOINT']}/{x}" for x in index],
+        columns=["Filename"],
+    )

--- a/cyto_ml/tests/conftest.py
+++ b/cyto_ml/tests/conftest.py
@@ -31,3 +31,10 @@ def image_batch(image_dir):
 @pytest.fixture
 def scivision_model():
     return truncate_model(load_model(SCIVISION_URL))
+
+
+@pytest.fixture
+def env_endpoint():
+    """None if ENDPOINT is not set in environment,
+    utility for skipping integration-type tests"""
+    return os.environ.get("ENDPOINT", None)

--- a/cyto_ml/tests/conftest.py
+++ b/cyto_ml/tests/conftest.py
@@ -36,5 +36,10 @@ def scivision_model():
 @pytest.fixture
 def env_endpoint():
     """None if ENDPOINT is not set in environment,
+    or it's set but to an arbitrary string,
     utility for skipping integration-type tests"""
-    return os.environ.get("ENDPOINT", None)
+    endpoint = os.environ.get("ENDPOINT", None)
+    # case in which we've got blether in the default config
+    if endpoint and "https" not in endpoint:
+        endpoint = None
+    return endpoint

--- a/cyto_ml/tests/test_object_store.py
+++ b/cyto_ml/tests/test_object_store.py
@@ -1,0 +1,32 @@
+"""Test the layout of the object store is what we expect
+
+untagged-images-lana
+untagged-images-wala
+tagged-images-lana
+tagged-images-wala
+
+Inside tagged-images-lana and tagged-images-wala there is a metadata.csv file and taxonomy.csv file.
+
+"""
+
+import pytest
+import s3fs
+from cyto_ml.data.s3 import s3_endpoint
+
+
+def test_endpoint(env_endpoint):
+    if not env_endpoint:
+        pytest.skip("no settings found for s3 endpoint")
+
+    store = s3_endpoint()
+    assert isinstance(store, s3fs.S3FileSystem)
+
+
+def test_img_ls(env_endpoint):
+    if not env_endpoint:
+        pytest.skip("no settings found for s3 endpoint")
+
+    store = s3_endpoint()
+    for bucket in ["untagged-images-lana", "untagged-images-wala"]:
+        filez = store.ls(bucket)
+        assert len(filez)

--- a/scripts/image_embeddings.py
+++ b/scripts/image_embeddings.py
@@ -23,7 +23,9 @@ if __name__ == "__main__":
     # Walkthrough here that shows the dataset wrapper being exercised
     # https://github.com/AnnaLinton/scivision_examples/blob/main/how-to-use-scivision.ipynb
 
-    dataset = load_dataset(f"{os.environ.get('ENDPOINT', '')}/metadata/intake.yml")
+    # Limited to the Lancaster FlowCam dataset for now:
+    catalog = "untagged-images-lana/intake.yml"
+    dataset = load_dataset(f"{os.environ.get('ENDPOINT')}/{catalog}")
     collection = vector_store("plankton")
 
     model = truncate_model(load_model(SCIVISION_URL))

--- a/scripts/intake_metadata.py
+++ b/scripts/intake_metadata.py
@@ -7,45 +7,39 @@ See also https://github.com/intake/intake-stac
 Via https://gallery.pangeo.io/repos/pangeo-data/pangeo-tutorial-gallery/intake.html#Build-an-intake-catalog
 
 """
-
-from cyto_ml.data.intake import intake_yaml
-from cyto_ml.data.s3 import s3_endpoint
-from s3fs import S3FileSystem
-import pandas as pd
 import os
-
-
-def image_index(endpoint: S3FileSystem, location: str):
-    """Find and likely later filter records in a bucket"""
-    index = endpoint.ls(location)
-    return pd.DataFrame(
-        [f"{os.environ['ENDPOINT']}/{x}" for x in index],
-        columns=["Filename"],
-    )
+from cyto_ml.data.intake import intake_yaml
+from cyto_ml.data.s3 import s3_endpoint, image_index
 
 
 if __name__ == "__main__":
 
     fs = s3_endpoint()
-    metadata = image_index(fs, "untagged-images")
+
+    # TODO this is a minimal change to only reflect the Lancaster data
+    # Need looking harder at the Wallingford data to decide how to treat it
+    # They're really distinct datasets, any benefit to sharing an index?
+    image_bucket = "untagged-images-lana"
+
+    metadata = image_index(fs, image_bucket)
 
     # Option to use a CSV as an index, rather than return the files
-    catalog = "metadata/catalog.csv"
+    catalog = f"{image_bucket}/catalog.csv"
     with fs.open(catalog, "w") as out:
         out.write(metadata.to_csv(index=False))
 
     cat_url = f"{os.environ['ENDPOINT']}/{catalog}"
 
-    with fs.open("metadata/intake.yml", "w") as out:
+    with fs.open(f"{image_bucket}/intake.yml", "w") as out:
         # Do we use a CSV driver and include the metadata?
         # out.write(write_yaml(f"{os.environ['ENDPOINT']}/{catalog}"))
 
         # See the issue here: https://github.com/NERC-CEH/plankton_ml/issues/3
         # About data improvements needed before a better way to read a bucket into s3
-        cat_test = f"{os.environ['ENDPOINT']}/untagged-images/19_10_Tank22_1.tif"
+        cat_test = f"{os.environ['ENDPOINT']}/untagged-images-lana/19_10_Tank22_1.tif"
 
-        # Our options for the whole collection look like:
-        # * a tiny http server that creates a zip, but assumes the images have more metadata
-        # * a tabular index instead, means we get less advantage from intake though
-
+        # Options for the whole collection look like:
+        # 1. a tiny http server that creates a zip, but assumes the images have more metadata
+        # 2. a tabular index instead, means we get less advantage from intake though
+        # We've gone with 2, needs documentation and continual revisiting
         out.write(intake_yaml(cat_test, cat_url))


### PR DESCRIPTION
See #12 for context (changes to the layout of the object store).

* Updates to the bucket locations (separate collections for FlowCam and flow cytometer images)
* `intake` metadata and catalog (just a file listing) have moved into the image buckets alongside the `cyto_app` metadata
* Adds a basic test that checks files can be read from the new buckets, only runs if connection details are set in `.env`

This is a small and quite blunt change - i think any more work on making it generic should defer until

* Revisit how the "decollage" process works in `cyto_app` so that the spatio-temporal metadata that _is_ available with the sources is preserved along with the individual images
* Have a much closer look at the flow cytometer data - if in theory we can [get spectrograms out of it](https://github.com/OBAMANEXT/cyz2json) as well, then just pushing the images through a classifier model is losing potential...

## To test
```
pip install -e .
py.test 
```

The tests for new bucket locations will skip unless you have `ENDPOINT` and the JASMIN access tokens set in `.env` (they should skip in the pipeline but that's ok imo, just doing a slow file listing)

@Kzra 