### PR TITLE
Add support for DVC, and switch out s3fs for boto3

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
-ENDPOINT="[object store URL goes here]"
-# These env variables are what s3fs sets from
-FSSPEC_S3_ENDPOINT_URL="[object store URL goes here]"
-FSSPEC_S3_KEY="[access key from JASMIN portal]"
-FSSPEC_S3_SECRET="[secret key from JASMIN portal]"
+# These env variables are what boto3 sets from
+AWS_URL_ENDPOINT="https://url.here"
+AWS_ACCESS_KEY_ID=""
+AWS_SECRET_ACCESS_KEY=""

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ export PATH=$PATH:exiftool
 
 `.env` contains environment variable names for S3 connection details for the [JASMIN object store](https://github.com/NERC-CEH/object_store_tutorial/). Fill these in with your own credentials. If you're not sure what the `ENDPOINT` should be, please reach out to one of the project contributors listed below. 
 
+
 ### Running tests
 
 `pytest` or `py.test`
@@ -98,8 +99,19 @@ streamlit run cyto_ml/visualisation/visualisation_app.py
 
 The demo should automatically open in your browser when you run streamlit. If it does not, connect using: http://localhost:8501.
 
-### TBC (object store upload, derived classifiers, etc)
+### Object Store API
 
+See the [Object Store API](https://github.com/NERC-CEH/object_store_api) project - RESTful interface to manage a data collection held in s3 object storage.
+
+## Data Version Control
+
+* [DVC with s3](https://github.com/NERC-CEH/llm-eval/blob/main/dvc.md) condensed walkthrough as part of the LLM evaluation project - complete this up to `dvc remote modify...` to set up the s3 connection.
+
+* [Tutorial: versioning data and models: What's next?](https://dvc.org/doc/use-cases/versioning-data-and-models/tutorial#whats-next) 
+
+* [Importing external data: Avoiding duplication](https://dvc.org/doc/user-guide/data-management/importing-external-data#avoiding-duplication) - is it this pattern?
+
+DAG / pipeline elements 
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ export PATH=$PATH:exiftool
  
 ### Object store connection
 
-`.env` contains environment variable names for S3 connection details for the [JASMIN object store](https://github.com/NERC-CEH/object_store_tutorial/). Fill these in with your own credentials. If you're not sure what the `ENDPOINT` should be, please reach out to one of the project contributors listed below. 
+`.env` contains environment variable names for S3 connection details for the [JASMIN object store](https://github.com/NERC-CEH/object_store_tutorial/). Fill these in with your own credentials. If you're not sure what the `AWS_URL_ENDPOINT` should be, please reach out to one of the project contributors listed below. 
 
 
 ### Running tests

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - python=3.12
   - pytorch
   - black
+  - boto3
   - chromadb
   - flake8
   - intake-xarray
@@ -18,7 +19,6 @@ dependencies:
   - pandas
   - pytest
   - python-dotenv
-  - s3fs
   - scikit-image
   - scikit-learn
   - xarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.12"
 description = "This package supports the processing and analysis of plankton sample data"
 readme = "README.md"
 dependencies = [
+    "boto3",
     "chromadb",
     "imagecodecs",
     "intake==0.7.0",
@@ -17,7 +18,6 @@ dependencies = [
     "plotly",
     "pyexiftool",
     "python-dotenv",
-    "s3fs", 
     "scikit-image", # secretly required by intake-xarray as default reader
     "streamlit", 
     "torch",

--- a/src/cyto_ml/data/s3.py
+++ b/src/cyto_ml/data/s3.py
@@ -1,31 +1,47 @@
 """Thin wrapper around the s3 object store with images and metadata"""
 
 import os
+from typing import Generator
 
+import boto3
 import pandas as pd
-import s3fs
 from dotenv import load_dotenv
 
+# Load standard connection details via .env
 load_dotenv()
 
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+AWS_URL_ENDPOINT = os.environ.get("AWS_URL_ENDPOINT", "")
 
-def s3_endpoint() -> s3fs.S3FileSystem:
-    """Return a reference to the object store,
-    reading the credentials set in the environment.
-    """
-    fs = s3fs.S3FileSystem(
-        anon=False,
-        key=os.environ.get("FSSPEC_S3_KEY", ""),
-        secret=os.environ.get("FSSPEC_S3_SECRET", ""),
-        client_kwargs={"endpoint_url": os.environ["ENDPOINT"]},
+
+def boto3_client() -> boto3.Session:
+    return boto3.client(
+        "s3",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        endpoint_url=AWS_URL_ENDPOINT,
     )
-    return fs
 
 
-def image_index(endpoint: s3fs.S3FileSystem, location: str) -> pd.DataFrame:
+def bucket_keys(
+    bucket_name: str, prefix: str = "/", delimiter: str = "/", start_after: str = ""
+) -> Generator[str, None, None]:
+    """Efficiently the contents of a bucket
+    Lifted from this highly-rated SO answer: https://stackoverflow.com/a/54014862"""
+
+    s3_paginator = boto3_client().get_paginator("list_objects_v2")
+    prefix = prefix.lstrip(delimiter)
+    start_after = (start_after or prefix) if prefix.endswith(delimiter) else start_after
+    for page in s3_paginator.paginate(Bucket=bucket_name, Prefix=prefix, StartAfter=start_after):
+        for content in page.get("Contents", ()):
+            yield content["Key"]
+
+
+def image_index(location: str) -> pd.DataFrame:
     """Find and likely later filter records in a bucket"""
-    index = endpoint.ls(location)
+    index = bucket_keys(location)
     return pd.DataFrame(
-        [f"{os.environ['ENDPOINT']}/{x}" for x in index],
+        [f"{os.environ['AWS_URL_ENDPOINT']}/{x}" for x in index],
         columns=["Filename"],
     )

--- a/src/cyto_ml/visualisation/visualisation_app.py
+++ b/src/cyto_ml/visualisation/visualisation_app.py
@@ -140,15 +140,8 @@ def main() -> None:
 
     st.set_page_config(layout="wide", page_title="Plankton image embeddings")
     st.title("Plankton image embeddings")
-    # it starts much slower on adding this
-    # the generated HTML is not lovely at all
 
-    # catalog = "untagged-images-lana/intake.yml"
-    # catalog_url = f"{os.environ.get('ENDPOINT')}/{catalog}"
-    # ds = intake_dataset(catalog_url)
-    # This way we've got a dataframe of the whole catalogue
-    # Do we gain even slightly from this when we have the same index in the embeddings
-    # index = ds.plankton().to_dask().compute()
+    # the generated HTML is not lovely at all
 
     st.session_state["random_img"] = random_image()
     show_random_image()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def env_endpoint():
     """None if ENDPOINT is not set in environment,
     or it's set but to an arbitrary string,
     utility for skipping integration-type tests"""
-    endpoint = os.environ.get("ENDPOINT", None)
+    endpoint = os.environ.get("AWS_URL_ENDPOINT", None)
     # case in which we've got blether in the default config
     if endpoint and "https" not in endpoint:
         endpoint = None

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -10,23 +10,25 @@ Inside tagged-images-lana and tagged-images-wala there is a metadata.csv file an
 """
 
 import pytest
-import s3fs
-from cyto_ml.data.s3 import s3_endpoint
+import botocore.client
+from cyto_ml.data.s3 import bucket_keys, boto3_client
+
+# Note - we skipped these tests unless running locally with credentials,
+# but could develop them with moto-server ...
 
 
 def test_endpoint(env_endpoint):
     if not env_endpoint:
         pytest.skip("no settings found for s3 endpoint")
 
-    store = s3_endpoint()
-    assert isinstance(store, s3fs.S3FileSystem)
+    store = boto3_client()
+    assert hasattr(store, "list_objects_v2")
 
 
 def test_img_ls(env_endpoint):
     if not env_endpoint:
         pytest.skip("no settings found for s3 endpoint")
 
-    store = s3_endpoint()
     for bucket in ["untagged-images-lana", "untagged-images-wala"]:
-        filez = store.ls(bucket)
-        assert len(filez)
+        filez = bucket_keys(bucket)
+        assert len([f for f in filez])


### PR DESCRIPTION
This starts adding support for DVC - as an interface to the image collection, with the intention of using its task graph components for model building.

There's little here on the DVC side as yet - links and notes in the `README` about following the approach being used [here for LLM testing and fine-tuning](https://github.com/NERC-CEH/llm-eval/), and how we might set it up to manage the collection "externally" (keeping the data on s3 and the metadata in source control).

In the process, I remember we'd discussed consolidating on one library for s3 access so i've switched out the `s3fs` interface for `boto3`, trying to follow the pattern set in [object_store_api](https://github.com/NERC-CEH/object_store_api). It's been useful to do, in that it touches everywhere we've got data interfaces, and can look at dropping support for `intake`.

I'm certainly _not_ suggesting going all-in on DVC until we've seen how it works in more scenarios - you find setups in other ecologies like `[RO-crate](https://www.researchobject.org/ro-crate)` and `[outpack](https://github.com/mrc-ide/outpack_server)` that share a lot of the same aims, but more focused on research data and possibly more community connections. For ML pipeline projects though, DVC is mature - it would be nice to get ahead of how it works for image ML projects, for [re-use potential elsewhere](https://github.com/NERC-CEH/rse_group/discussions/12)

Anyway, I'm done for the week, so this is currently explicitly a draft, against `post-layout-change` (still needs merged) so you can see the diff, which includes

* Replace the dependency on `s3fs` with `boto3` (improvements welcome!)
* Adapt the tests to reflect the above
* Adapt the script that creates catalogue metadata to reflect the above - which now needs rethought in terms of a task graph
* Link collection in the README outlining a reasonable approach to managing an initial image collection (for model building, rather than for inference) with DVC





   


