### PR TITLE
Quick visualisation of classification results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Container for FastAPI model serving
+FROM python:3.12
+
+WORKDIR /app
+
+COPY ./src /app/src
+COPY pyproject.toml /app/pyproject.toml
+
+RUN pip install --no-cache-dir --upgrade -e .
+
+# Local copies of model weights
+COPY ./data /app/data
+
+CMD ["fastapi", "run", "src/cyto_ml/models/api.py", "--port", "8000"]

--- a/src/cyto_ml/data/image.py
+++ b/src/cyto_ml/data/image.py
@@ -13,12 +13,18 @@ class ImageProcessingError(Exception):
     pass
 
 
-def load_image(path: str) -> torch.Tensor:
+def load_image(path: str, normalise_func: Optional[str] = "base_normalise") -> torch.Tensor:
+    """Given an image path, return a tensor suitable to hand to a model
+    Optional normalise_func which defaults to converting to a range between 0..1
+    """
     img = Image.open(path)
-    return prepare_image(img)
+    return prepare_image(img, normalise_func=normalise_func)
 
 
 def load_image_from_url(url: str, normalise_func: Optional[str] = "base_normalise") -> torch.Tensor:
+    """Given an image url, return a tensor suitable to hand to a model
+    Optional normalise_func which defaults to converting to a range between 0..1
+    """
     response = requests.get(url)
     if response.status_code == 200:
         img = Image.open(BytesIO(response.content))
@@ -54,7 +60,19 @@ def prepare_image(image: Image, normalise_func: Optional[str] = "base_normalise"
 
 
 def base_normalise() -> transforms.Compose:
+    """
+    Baseline - don't standardise the values, just tensorise
+    (which automatically translates to a 0-1 range)
+    """
     return transforms.ToTensor()
+
+
+def resize_normalise() -> transforms.Compose:
+    """
+    Resize to 256x256
+    https://github.com/ukceh-rse/ViT-LASNet/blob/36235f9b992a6c345f1010dab133549d20f181d9/test/test.py#L115
+    """
+    return transforms.Compose([transforms.Resize((256, 256)), transforms.ToTensor()])
 
 
 def normalise_flowlr(image: Image) -> np.array:

--- a/src/cyto_ml/data/vectorstore.py
+++ b/src/cyto_ml/data/vectorstore.py
@@ -182,6 +182,16 @@ class SQLiteVecStore(VectorStore):
         results = self.db.execute(query, [embeddings, n_results]).fetchall()
         return [i for j in results for i in j]
 
+    def labelled(self, label: str, n_results: int = 50) -> List[str]:
+        labelled = self.db.execute(
+            """select url from embeddings where classification = ? limit ?""", (label, n_results)
+        ).fetchall()
+        return [i for j in labelled for i in j]
+
+    def classes(self) -> List[str]:
+        classes = self.db.execute("""select distinct classification from embeddings""").fetchall()
+        return [i for j in classes for i in j]
+
     def embeddings(self) -> List[List]:
         embeddings = self.db.execute("""select embedding from embeddings""").fetchall()
         return [deserialize(i) for j in embeddings for i in j]

--- a/src/cyto_ml/visualisation/pages/03_classes.py
+++ b/src/cyto_ml/visualisation/pages/03_classes.py
@@ -1,0 +1,77 @@
+import logging
+
+import streamlit as st
+
+from cyto_ml.visualisation.app import cached_image, collections, store
+
+logging.basicConfig(level=logging.INFO)
+
+DEPTH = 8
+
+
+@st.cache_data
+def add_more() -> None:
+    st.session_state["depth"] += DEPTH
+
+
+def do_less() -> None:
+    st.session_state["depth"] -= DEPTH
+
+
+def by_class() -> None:
+    classed = store(st.session_state["collection"]).labelled(st.session_state["class_label"])
+    st.session_state["closest"] = classed
+
+
+def show_cluster() -> None:
+    for _ in range(0, st.session_state["depth"]):
+        cols = st.columns(DEPTH)
+
+        for c in cols:
+            c.empty()
+            try:
+                next_image = st.session_state["closest"].pop()
+            except IndexError:
+                break
+            c.image(cached_image(next_image), width=60)
+
+
+# TODO some visualisation, actual content, etc
+def main() -> None:
+    # duplicate logic from main page, how should this state be shared?
+
+    colls = collections()
+    if "collection" not in st.session_state:
+        st.session_state["collection"] = colls[0]
+
+    classlist = store(st.session_state["collection"]).classes()
+    if "class_label" not in st.session_state:
+        st.session_state["class_label"] = classlist[0]
+
+    st.selectbox(
+        "image collection",
+        colls,
+        key="collection",
+    )
+
+    # show this many images * 8 across
+    if "depth" not in st.session_state:
+        st.session_state["depth"] = 8
+
+    st.selectbox(
+        "class label",
+        classlist,
+        key="class_label",
+        on_change=by_class,
+    )
+
+    st.button("more", on_click=add_more)
+
+    st.button("less", on_click=do_less)
+
+    by_class()
+    show_cluster()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prepare_image.py
+++ b/tests/test_prepare_image.py
@@ -9,10 +9,14 @@ from cyto_ml.data.image import load_image
 def test_single_image(single_image):
     # Tensorise the image (potentially normalise if we have useful values)
     prepared_image = load_image(single_image)
-
     # Check if the shape is correct (batch dimension added)
     assert prepared_image.shape == torch.Size([1, 3, 80, 79])
 
+    assert torch.all((prepared_image >= 0.0) & (prepared_image <= 1.0))
+
+    # Test resizing of images to 256*256
+    prepared_image = load_image(single_image, normalise_func="resize_normalise")
+    assert prepared_image.shape == torch.Size([1, 3, 256, 256])
     assert torch.all((prepared_image >= 0.0) & (prepared_image <= 1.0))
 
 


### PR DESCRIPTION
* Fully switches to the sqlite backend for embeddings + metadata
* Adds a classification column to the table, read into it from the API response to an image URL
* Add an optional normalisation function to the image preprocessing, not yet being passed through from the API
* Small improvements to documentation and tests

As ever this is work-in-progress but wanted to get it pushed through in order to switch tracks and look at our deployment options for pipelines - #47 - and how we can evolve this sensibly from a single VM deployment to (eventually) a managed k8s one with the option of a different workflow engine

The instructions for testing and running this should be covered in the README, probably some missing, also aiming to write some walkthrough documentation while watching pipelines run