### PR TITLE
Use directory names to derive pipeline experiment names

### DIFF
--- a/scripts/run_luigi_pipeline.py
+++ b/scripts/run_luigi_pipeline.py
@@ -1,15 +1,41 @@
+import argparse
 import luigi
 from cyto_ml.pipeline.pipeline_decollage import FlowCamPipeline
+from cyto_ml.data.flowcam import parse_filename
+import logging
+logging.basicConfig(level=logging.INFO)
 
 
 if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+    prog='Luigi FlowCam pipeline',
+    description='Triggers the process of decollaging images, embedding spatio-temporal metadata in headers, and uploading to s3 storage',
+    )
+
+    parser.add_argument('-o', '--output_directory', type=str, default="./data/images_decollage", help="directory for intermediate data")
+    parser.add_argument('-d', '--directory', type=str, default="./tests/fixtures/MicrobialMethane_MESO_Tank10_54.0143_-2.7770_04052023_1", help='Enable verbose mode')
+    parser.add_argument('-s', '--s3_bucket', type=str, default="untagged-images-lana")
+    parser.add_argument('-e', '--experiment_name', type=str)
+    args = parser.parse_args()
+
+    experiment = args.experiment_name
+    if not experiment:
+        try:
+            prefix, _, _, date, _ = parse_filename(args.directory)
+            experiment = ''.join([prefix, date])
+        except ValueError as err:
+            logging.info("Could't figure out experiment name and date from {args.directory} - please call this with --experiment_name to set this")
+            logging.debug(err)
+            exit
+
     luigi.build(
         [
             FlowCamPipeline(
-                directory="./tests/fixtures/MicrobialMethane_MESO_Tank10_54.0143_-2.7770_04052023_1",
-                output_directory="./data/images_decollage",
-                experiment_name="test_experiment",
-                s3_bucket="test-upload-alba",
+                directory=args.directory,
+                output_directory=args.output_directory,
+                experiment_name=experiment,
+                s3_bucket=args.s3_bucket,
             )
         ],
         local_scheduler=False,

--- a/src/cyto_ml/data/flowcam.py
+++ b/src/cyto_ml/data/flowcam.py
@@ -59,6 +59,9 @@ def parse_filename(filename: str) -> tuple:
 
         # There could be an arbitrary number of underscores before the coords
         prefix = filename.split(lat)[0]
+        # This could be a directory or a full path
+        if "/" in prefix:
+            prefix = prefix.split("/")[-1]
         return (prefix, lat, lon, date, depth)
 
     else:

--- a/src/cyto_ml/data/flowcam.py
+++ b/src/cyto_ml/data/flowcam.py
@@ -8,6 +8,7 @@ import glob
 import logging
 import os
 import re
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -36,19 +37,45 @@ def window_slice(image: np.ndarray, x: int, y: int, height: int, width: int) -> 
 
 def headers_from_filename(filename: str) -> dict:
     """Attempt to extract lon/lat and date, option of depth, from filename
-    Return a dict with key-value pairs for use as EXIF headers
-    """
-    headers = {}
-    pattern = r"_(-?\d+\.\d+)_(-?\d+\.\d+)_(\d{8})(?:_(\d+))?"
+    Return a dict with key-value pairs for use as EXIF headers"""
+    try:
+        _, lat, lon, date, _ = parse_filename(filename)
+    except ValueError as err:
+        logging.debug(err)
+        # No filename encoded metadata to return
+        return {}
+    return exif_headers(lat, lon, date)
 
+
+def parse_filename(filename: str) -> tuple:
+    """Attempt to extract file prefix, lon, lat, date, depth, from filename"""
+    pattern = r"_(-?\d+\.\d+)_(-?\d+\.\d+)_(\d{8})(?:_(\d+))?"
     match = re.search(pattern, filename)
     if match:
+        # We've left space for "depth" here
+        # But all the observed values are not depths, they're like session IDs e.g. _1
+        # TODO check this assumption with the folks in the lab
         lat, lon, date, depth = match.groups()
-        # https://exiftool.org/TagNames/GPS.html
-        headers["GPSLatitude"] = lat
-        headers["GPSLongitude"] = lon
-        headers["DateTimeOriginal"] = date  # better to leave as date than pad with zero hours?
-        # TODO most depth matches will be spurious, what are the rules (refer to Kelly?
+
+        # There could be an arbitrary number of underscores before the coords
+        prefix = filename.split(lat)[0]
+        return (prefix, lat, lon, date, depth)
+
+    else:
+        logging.warning(f"No coordinates or date found in filename: {filename}")
+        return ()
+
+
+def exif_headers(lon: float, lat: float, date: str, depth: Optional[int] = 0) -> dict:
+    """
+    Given lat, lon, date and option of depth, write and return a dict with EXIF standard tags as keys
+    """
+    headers = {}
+    # https://exiftool.org/TagNames/GPS.html
+    headers["GPSLatitude"] = lat
+    headers["GPSLongitude"] = lon
+    headers["DateTimeOriginal"] = date  # better to leave as date than pad with zero hours?
+    if depth > 0:
         headers["GPSAltitude"] = depth  # can we use negative altitude as bathymetric depth?
     return headers
 

--- a/src/cyto_ml/pipeline/pipeline_decollage.py
+++ b/src/cyto_ml/pipeline/pipeline_decollage.py
@@ -112,11 +112,12 @@ class UploadDecollagedImagesToS3(luigi.Task):
     directory = luigi.Parameter()
     output_directory = luigi.Parameter()
     s3_bucket = luigi.Parameter()
+    experiment_name = luigi.Parameter()
     api_url = luigi.Parameter(default=API_URL)
 
     def requires(self) -> List[luigi.Task]:
         return DecollageImages(
-            directory=self.directory, output_directory=self.output_directory, experiment_name="test_experiment"
+            directory=self.directory, output_directory=self.output_directory, experiment_name=self.experiment_name
         )
 
     def output(self) -> luigi.Target:
@@ -190,6 +191,7 @@ class FlowCamPipeline(luigi.WrapperTask):
             output_directory=self.output_directory,
             s3_bucket=self.s3_bucket,
             api_url=self.api_url,
+            experiment_name=self.experiment_name,
         )
 
 

--- a/src/cyto_ml/pipeline/pipeline_decollage.py
+++ b/src/cyto_ml/pipeline/pipeline_decollage.py
@@ -10,7 +10,7 @@ import requests
 from dotenv import load_dotenv
 from skimage.io import imread, imsave
 
-from cyto_ml.data.decollage import headers_from_filename, lst_metadata, window_slice, write_headers
+from cyto_ml.data.flowcam import headers_from_filename, lst_metadata, window_slice, write_headers
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/tests/test_decollage.py
+++ b/tests/test_decollage.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from skimage.io import imread
-from cyto_ml.data.decollage import (
+from cyto_ml.data.flowcam import (
     lst_metadata,
     window_slice,
     headers_from_filename,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -102,6 +102,7 @@ def test_upload_to_api(temp_dir, mocker):
         directory=str(temp_dir),
         output_directory=str(temp_dir),
         s3_bucket="mock_bucket",
+        experiment_name="mock_experiment",
     )
 
     luigi.build([task], local_scheduler=True)
@@ -126,6 +127,7 @@ def test_upload_to_api(temp_dir, mocker):
         directory=str(size_dir),
         output_directory=str(size_dir),
         s3_bucket="mock_bucket",
+        experiment_name="mock_experiment",
     )
 
     luigi.build([task], local_scheduler=True)


### PR DESCRIPTION
* Adds `argparse` arguments to call this either in a container or via cron 
* Fixes an issue where `experiment_name` was not being passed through all pipeline tasks
* Uses the agreed file naming conventions (see #60 ) to derive a unique experiment name for images in a collection
* Tiny refactoring of the name parsing into a standalone function